### PR TITLE
Add ServiceNow Widget Data Exposure detection advisory

### DIFF
--- a/.config/modules.json
+++ b/.config/modules.json
@@ -467,6 +467,12 @@
             "category": "recon",
             "module": "Passive_Links",
             "description": "Fetch known URLs from OTX, Wayback Machine, and Common Crawl"
+        },
+        {
+            "id": "0076",
+            "category": "advisory",
+            "module": "ServiceNow_Widget_Data_Exposure",
+            "description": "Detect misconfigured ServiceNow instances exposing sensitive data via the widget-simple-list API"
         }
     ]
 }

--- a/lib/Spellbook/Advisory/ServiceNow_Widget_Data_Exposure.pm
+++ b/lib/Spellbook/Advisory/ServiceNow_Widget_Data_Exposure.pm
@@ -1,0 +1,119 @@
+package Spellbook::Advisory::ServiceNow_Widget_Data_Exposure {
+    use strict;
+    use warnings;
+    use JSON;
+    use Try::Tiny;
+    use HTTP::Request;
+    use HTTP::Cookies;
+    use Spellbook::Core::UserAgent;
+
+    our $VERSION = '0.0.1';
+
+    my @TABLE_LIST = (
+        't=cmdb_model&f=name',
+        't=cmn_department&f=app_name',
+        't=kb_knowledge&f=text',
+        't=licensable_app&f=app_name',
+        't=alm_asset&f=display_name',
+        't=sys_attachment&f=file_name',
+        't=sys_attachment_doc&f=data',
+        't=oauth_entity&f=name',
+        't=cmn_cost_center&f=name',
+        't=sc_cat_item&f=name',
+        't=cmn_company&f=name',
+        't=customer_account&f=name',
+        't=sys_email_attachment&f=email',
+        't=cmn_notif_device&f=email_address',
+        't=incident&f=short_description',
+        't=work_order&f=number',
+        't=incident&f=number',
+        't=sn_customerservice_case&f=number',
+        't=task&f=number',
+        't=customer_project&f=number',
+        't=customer_project_task&f=number',
+        't=sys_user&f=name',
+        't=customer_contact&f=name',
+    );
+
+    sub new {
+        my ($self, $parameters) = @_;
+        my ($help, $target, $fast_check, @result);
+
+        Getopt::Long::GetOptionsFromArray (
+            $parameters,
+            'h|help'       => \$help,
+            't|target=s'   => \$target,
+            'f|fast-check' => \$fast_check
+        );
+
+        if ($target) {
+            if ($target !~ /^http(?:s)?:\/\//msx) {
+                $target = "https://$target";
+            }
+
+            $target =~ s/\/+$//msx;
+
+            my $user_agent = Spellbook::Core::UserAgent -> new();
+            my $cookie_jar = HTTP::Cookies -> new();
+            $user_agent -> cookie_jar($cookie_jar);
+
+            my $initial_response = $user_agent -> get($target);
+
+            my $g_ck;
+            if ($initial_response -> content() =~ /var\s+g_ck\s*=\s*'([a-zA-Z0-9]+)'/msx) {
+                $g_ck = $1;
+            }
+
+            my @tables = $fast_check ? ('t=kb_knowledge&f=text') : @TABLE_LIST;
+
+            for my $table (@tables) {
+                try {
+                    my $endpoint = "$target/api/now/sp/widget/widget-simple-list?$table";
+
+                    my $headers = HTTP::Headers -> new(
+                        'Content-Type' => 'application/json',
+                        'Accept'       => 'application/json',
+                        'Connection'   => 'close',
+                    );
+
+                    if ($g_ck) {
+                        $headers -> header('X-UserToken' => $g_ck);
+                    }
+
+                    my $request  = HTTP::Request -> new('POST', $endpoint, $headers, '{}');
+                    my $response = $user_agent -> request($request);
+
+                    if ($response -> code() == 200 || $response -> code() == 201) {
+                        my $body = decode_json($response -> content());
+
+                        if (
+                            exists $body -> {result}
+                            && exists $body -> {result}{data}
+                            && exists $body -> {result}{data}{count}
+                            && $body -> {result}{data}{count} > 0
+                            && exists $body -> {result}{data}{list}
+                            && scalar @{$body -> {result}{data}{list}} > 0
+                        ) {
+                            push @result, $endpoint;
+                        }
+                    }
+                };
+            }
+
+            return @result;
+        }
+
+        if ($help) {
+            return "
+                \rAdvisory::ServiceNow_Widget_Data_Exposure
+                \r==========================================
+                \r-h, --help        See this menu
+                \r-t, --target      Define a target (ServiceNow instance URL)
+                \r-f, --fast-check  Only check the kb_knowledge table\n\n";
+        }
+
+        return 0;
+    }
+}
+
+1;

--- a/lib/Spellbook/Advisory/ServiceNow_Widget_Data_Exposure.pm
+++ b/lib/Spellbook/Advisory/ServiceNow_Widget_Data_Exposure.pm
@@ -64,7 +64,10 @@ package Spellbook::Advisory::ServiceNow_Widget_Data_Exposure {
                 $g_ck = $1;
             }
 
-            my @tables = $fast_check ? ('t=kb_knowledge&f=text') : @TABLE_LIST;
+            my @tables = @TABLE_LIST;
+            if ($fast_check) {
+                @tables = ('t=kb_knowledge&f=text');
+            }
 
             for my $table (@tables) {
                 try {


### PR DESCRIPTION
### What was a problem?

ServiceNow instances can be misconfigured to expose sensitive data through the `widget-simple-list` API endpoint. There was no detection mechanism to identify instances vulnerable to this data exposure vulnerability.

### How this PR fixes the problem?

This PR adds a new advisory module `ServiceNow_Widget_Data_Exposure` that:

1. **Detects misconfigured ServiceNow instances** by probing the `/api/now/sp/widget/widget-simple-list` endpoint with various table and field combinations
2. **Extracts the g_ck token** from the initial response to authenticate requests when available
3. **Supports two scanning modes**:
   - Full scan: Tests 23 different ServiceNow tables (cmdb_model, kb_knowledge, sys_user, incident, etc.)
   - Fast check mode: Only tests the kb_knowledge table for quick validation
4. **Identifies data exposure** by checking for successful responses (200/201) with non-empty result sets
5. **Reports vulnerable endpoints** that expose sensitive data

The module is registered in the modules configuration with ID 0076 under the advisory category.

### Check lists

- [x] Coding style (indentation, Perl conventions followed)
- [ ] Test passed (module integration testing pending)

### Additional Comments

This advisory helps security teams identify ServiceNow instances with improper access controls on the widget API that could leak sensitive information from various tables including user data, attachments, incidents, and knowledge base articles.

https://claude.ai/code/session_01QfPcXLQq5Kk4TA8X7Rx3bE