### PR TITLE
fix(Dockerfile): upgrade system dependencies for Perl 5.42 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM perl:5.40-slim
+FROM perl:5.42-slim
 
 WORKDIR /usr/src/spellbook
 COPY . .
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
     libpcap-dev \
     masscan \
     libexpat1-dev \
+    libssl-dev \
+    zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN cpanm --notest --installdeps .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.42-slim
+FROM perl:5.40-slim
 
 WORKDIR /usr/src/spellbook
 COPY . .
@@ -6,6 +6,7 @@ COPY . .
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpcap-dev \
     masscan \
+    libexpat1-dev \
  && rm -rf /var/lib/apt/lists/*
 
 RUN cpanm --notest --installdeps .

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires 'Find::Lib',           '1.04';
 requires 'YAML::Tiny',          '1.76';
 requires 'Masscan::Client', '0.21';
 requires 'Net::DNS', '1.53';
-requires 'WWW::Mechanize', '2.22';
+requires 'WWW::Mechanize', '2.20';
 requires 'Net::IP',             '1.26';
 requires 'UUID::Tiny',          '1.04';
 requires 'WWW::Wappalyzer',     '2.00';

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,7 @@ requires 'Find::Lib',           '1.04';
 requires 'YAML::Tiny',          '1.76';
 requires 'Masscan::Client', '0.21';
 requires 'Net::DNS', '1.53';
-requires 'WWW::Mechanize', '2.20';
+requires 'WWW::Mechanize', '2.22';
 requires 'Net::IP',             '1.26';
 requires 'UUID::Tiny',          '1.04';
 requires 'WWW::Wappalyzer',     '2.00';

--- a/cpanfile
+++ b/cpanfile
@@ -16,7 +16,7 @@ requires 'LWP::UserAgent', '6.83';
 requires 'XML::Simple', '2.25';
 requires 'Nmap::Scanner', '1.0';
 requires 'Image::ExifTool', '13.55';
-requires 'Mojolicious', '9.45';
+requires 'Mojolicious', '9.46';
 requires 'OpenAI::API', '0.37';
 requires 'Try::Tiny', '0.32';
 requires 'Readonly', '2.05';

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,7 @@ requires 'threads',             '2.26';
 requires 'Find::Lib',           '1.04';
 requires 'YAML::Tiny',          '1.76';
 requires 'Masscan::Client', '0.21';
-requires 'Net::DNS', '1.53';
+requires 'Net::DNS', '1.55';
 requires 'WWW::Mechanize', '2.22';
 requires 'Net::IP',             '1.26';
 requires 'UUID::Tiny',          '1.04';


### PR DESCRIPTION
## Problem

The Docker build workflow was failing with multiple modules not being installed. Analysis of the CI log identified two root causes:

### 1. Missing system libraries for XS module compilation

Several modules failed to build due to missing system-level dependencies:

- `XML::Parser` configure failed → missing `libexpat1-dev` → caused `XML::Simple` to fail
- `Net::SSLeay` / `IO::Socket::SSL` build failed → missing `libssl-dev` → caused the entire LWP/HTTPS stack to fail (`LWP::UserAgent`, `WWW::Mechanize`, `HTTP::Cookies`, `HTTP::Request::Common`, `OpenAI::API`)

### 2. Missing build toolchain (explicit)

`build-essential` added explicitly to guarantee `gcc` and `make` are available for all XS compilations.

## Changes

**`Dockerfile`** — added system packages:
- `build-essential`: gcc/make (explicit guarantee)
- `libexpat1-dev`: required by `XML::Parser` / `XML::Simple`
- `libssl-dev`: required by `Net::SSLeay` / `IO::Socket::SSL` / LWP HTTPS stack
- `zlib1g-dev`: HTTP compression support

**`cpanfile`** — corrected module versions that were not available on CPAN:
- `Net::DNS`: `1.55`
- `WWW::Mechanize`: `2.22` (duplicate entry removed)
- `Mojolicious`: `9.46`