### PR TITLE
fix(ci): remove hardcoded base/head from TruffleHog secret scanning

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,6 +30,8 @@ jobs:
         continue-on-error: true
         with:
           path: ./
+          base: "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}"
+          head: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}"
           extra_args: --debug
 
       - name: Scan Results Status

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,8 +30,6 @@ jobs:
         continue-on-error: true
         with:
           path: ./
-          base: "${{ github.event.repository.default_branch }}"
-          head: HEAD
           extra_args: --debug
 
       - name: Scan Results Status


### PR DESCRIPTION
## Summary

- Removes explicit `base` and `head` inputs from the TruffleHog step that caused the workflow to always fail on pushes to `main`
- When `base: main` and `head: HEAD` both resolve to the same commit (i.e. any direct push to `main`), TruffleHog exits with error: *"BASE and HEAD commits are the same"*
- Dropping these inputs lets TruffleHog use its built-in event-aware logic: for `push` events it uses `github.event.before`/`github.event.after` (always different), and for `pull_request` events it uses the PR base/head refs automatically

## Test plan

- [ ] Merge to `main` and confirm the Secret Scanning workflow passes without the *"BASE and HEAD commits are the same"* error
- [ ] Open a PR and confirm the workflow also passes on `pull_request` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9SH4jcDQGxtgLoiGxYLRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9SH4jcDQGxtgLoiGxYLRf)_