### PR TITLE
fix(ci): generate SARIF from TruffleHog JSON output and upgrade upload-sarif to v4

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -11,7 +11,6 @@ permissions:
   id-token: write
   issues: write
   pull-requests: write
-  security-events: write
 
 jobs:
   TruffleHog:
@@ -27,74 +26,13 @@ jobs:
 
       - name: Secret Scanning - TruffleHog
         id: trufflehog
+        uses: trufflesecurity/trufflehog@main
         continue-on-error: true
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            RANGE="--since-commit ${{ github.event.pull_request.base.sha }} --branch ${{ github.event.pull_request.head.sha }}"
-          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            RANGE="--since-commit ${{ github.event.before }}"
-          else
-            RANGE=""
-          fi
-          docker run --rm -v "$GITHUB_WORKSPACE:/repo" \
-            ghcr.io/trufflesecurity/trufflehog:latest \
-            git file:///repo/ $RANGE \
-            --json --no-update --fail \
-            > trufflehog-output.json
-
-      - name: Convert TruffleHog output to SARIF
-        if: always()
-        run: |
-          python3 << 'EOF'
-          import json
-
-          results = []
-          try:
-              with open('trufflehog-output.json') as f:
-                  for line in f:
-                      if line.strip():
-                          try:
-                              results.append(json.loads(line.strip()))
-                          except json.JSONDecodeError:
-                              pass
-          except FileNotFoundError:
-              pass
-
-          sarif = {
-              "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-              "version": "2.1.0",
-              "runs": [{
-                  "tool": {"driver": {"name": "TruffleHog"}},
-                  "results": [{
-                      "ruleId": r.get("DetectorName", "secret"),
-                      "level": "error",
-                      "message": {
-                          "text": "Secret detected: " + r.get("DetectorName", "unknown") +
-                                  (" (verified)" if r.get("Verified") else " (unverified)")
-                      },
-                      "locations": [{
-                          "physicalLocation": {
-                              "artifactLocation": {
-                                  "uri": r.get("SourceMetadata", {}).get("Data", {}).get("Git", {}).get("file", "unknown")
-                              },
-                              "region": {
-                                  "startLine": max(1, int(r.get("SourceMetadata", {}).get("Data", {}).get("Git", {}).get("line", 1) or 1))
-                              }
-                          }
-                      }]
-                  } for r in results]
-              }]
-          }
-
-          with open('trufflehog.sarif', 'w') as f:
-              json.dump(sarif, f, indent=2)
-          EOF
-
-      - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
         with:
-          sarif_file: trufflehog.sarif
+          path: ./
+          base: "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}"
+          head: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}"
+          extra_args: --debug
 
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -27,16 +27,71 @@ jobs:
 
       - name: Secret Scanning - TruffleHog
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
         continue-on-error: true
-        with:
-          path: ./
-          base: "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}"
-          head: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}"
-          extra_args: --debug
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            RANGE="--since-commit ${{ github.event.pull_request.base.sha }} --branch ${{ github.event.pull_request.head.sha }}"
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            RANGE="--since-commit ${{ github.event.before }}"
+          else
+            RANGE=""
+          fi
+          docker run --rm -v "$GITHUB_WORKSPACE:/repo" \
+            ghcr.io/trufflesecurity/trufflehog:latest \
+            git file:///repo/ $RANGE \
+            --json --no-update --fail \
+            > trufflehog-output.json
+
+      - name: Convert TruffleHog output to SARIF
+        if: always()
+        run: |
+          python3 << 'EOF'
+          import json
+
+          results = []
+          try:
+              with open('trufflehog-output.json') as f:
+                  for line in f:
+                      if line.strip():
+                          try:
+                              results.append(json.loads(line.strip()))
+                          except json.JSONDecodeError:
+                              pass
+          except FileNotFoundError:
+              pass
+
+          sarif = {
+              "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+              "version": "2.1.0",
+              "runs": [{
+                  "tool": {"driver": {"name": "TruffleHog"}},
+                  "results": [{
+                      "ruleId": r.get("DetectorName", "secret"),
+                      "level": "error",
+                      "message": {
+                          "text": "Secret detected: " + r.get("DetectorName", "unknown") +
+                                  (" (verified)" if r.get("Verified") else " (unverified)")
+                      },
+                      "locations": [{
+                          "physicalLocation": {
+                              "artifactLocation": {
+                                  "uri": r.get("SourceMetadata", {}).get("Data", {}).get("Git", {}).get("file", "unknown")
+                              },
+                              "region": {
+                                  "startLine": max(1, int(r.get("SourceMetadata", {}).get("Data", {}).get("Git", {}).get("line", 1) or 1))
+                              }
+                          }
+                      }]
+                  } for r in results]
+              }]
+          }
+
+          with open('trufflehog.sarif', 'w') as f:
+              json.dump(sarif, f, indent=2)
+          EOF
 
       - name: Upload SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: trufflehog.sarif

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,6 +30,8 @@ jobs:
         continue-on-error: true
         with:
           path: ./
+          base: "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}"
+          head: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}"
           extra_args: --debug
 
       - name: Scan Results Status

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -11,6 +11,7 @@ permissions:
   id-token: write
   issues: write
   pull-requests: write
+  security-events: write
 
 jobs:
   TruffleHog:
@@ -33,6 +34,12 @@ jobs:
           base: "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}"
           head: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}"
           extra_args: --debug
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trufflehog.sarif
 
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -30,8 +30,6 @@ jobs:
         continue-on-error: true
         with:
           path: ./
-          base: "${{ github.event.repository.default_branch }}"
-          head: HEAD
           extra_args: --debug
 
       - name: Scan Results Status


### PR DESCRIPTION
## Summary

- Fixes `Error: Path does not exist: trufflehog.sarif` — the TruffleHog action only writes annotations to the runner log, it never creates a `.sarif` file on disk
- Switches to running TruffleHog directly via docker with `--json` output, then converts findings to SARIF using an inline Python step
- Upgrades `codeql-action/upload-sarif` from `v3` to `v4`, resolving both the Node.js 20 and CodeQL Action v3 deprecation warnings

## How it works

1. **TruffleHog** runs via docker with `--json --fail`, writing one JSON object per finding to `trufflehog-output.json`
2. **Convert to SARIF** (`if: always()`) — reads the JSON output and generates a valid `trufflehog.sarif` file; produces an empty results array if no findings, so the file always exists
3. **Upload SARIF** to GitHub Code Scanning
4. **Fail the job** if TruffleHog exited non-zero (secrets detected)

## Test plan

- [ ] Clean scan: workflow passes, SARIF uploaded with zero results
- [ ] Scan with secrets: workflow fails, findings appear under Security → Code scanning alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9SH4jcDQGxtgLoiGxYLRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9SH4jcDQGxtgLoiGxYLRf)_